### PR TITLE
REPL複数行対応

### DIFF
--- a/plsp.py
+++ b/plsp.py
@@ -61,11 +61,21 @@ def extend_env(env, params, arg_values):
     return new_env
 
 
+def count_parentheses(s):
+    return s.count('(') - s.count(')')
+
 def repl(prompt='plsp> '):
     global_env = initial_env()
     while True:
         try:
-            user_input = input(prompt)
+            user_input = ""
+            parentheses_count = 0
+            while True:
+                line = input(prompt if parentheses_count == 0 else "... ")
+                user_input += line + "\n"
+                parentheses_count += count_parentheses(line)
+                if parentheses_count == 0 and line.strip() != '':
+                    break
             if user_input.strip() == '':
                 continue
             val = evaluate(parse(user_input), global_env)


### PR DESCRIPTION
chatGPTの回答:

一般的なLISPインタプリターのREPLでは、括弧のペアが完全に一致しない場合、ユーザーが改行しても引き続き入力を受け付けることが一般的です。
括弧のペアが完全に一致した時点で、入力が完了し、入力されたコードの評価が開始されます。この挙動を実現するには、repl関数を以下のように修正してください。
```
def count_parentheses(s):
    return s.count('(') - s.count(')')

def repl(prompt='plsp> '):
    global_env = initial_env()
    while True:
        try:
            user_input = ""
            parentheses_count = 0
            while True:
                line = input(prompt if parentheses_count == 0 else "... ")
                user_input += line + "\n"
                parentheses_count += count_parentheses(line)
                if parentheses_count == 0 and line.strip() != '':
                    break
            if user_input.strip() == '':
                continue
            val = evaluate(parse(user_input), global_env)
            if val is not None:
                print(schemestr(val))
        except Exception as e:
            print(f"{type(e).__name__}: {e}")
```
count_parentheses関数を追加して、開いた括弧と閉じた括弧の数の差を計算します。
repl関数内の入力ループでは、括弧のペアが完全に一致する（parentheses_count == 0）まで入力を続けます。
入力が途中の場合、プロンプトを"... "に変更して、ユーザーに続きの入力を促します。

この修正により、括弧のペアが完全に一致するまで改行を含むLISPコードを入力できます。
括弧のペアが完全に一致したら、入力が終了し、入力されたコードの評価が開始されます。